### PR TITLE
🐛 removed 100vh height from container

### DIFF
--- a/frontend/source/scss/components/molecules/_float-image.scss
+++ b/frontend/source/scss/components/molecules/_float-image.scss
@@ -1,6 +1,3 @@
-.#{organism('container')} {
-	height: 100vh;
-}
 
 .#{molecule('shift-image')} {
 	display: grid;


### PR DESCRIPTION
the iniital commit for the float-image component required a 100vh on its container in order to see the parallax effect. This is no longer needed for the effect and was causing breaking issues in some components